### PR TITLE
Change "Export" button text, change method for exporting projects file

### DIFF
--- a/django_bestiary/projects/templates/projects/project.html
+++ b/django_bestiary/projects/templates/projects/project.html
@@ -85,7 +85,7 @@
     <div style="height:10px"></div>
     <form method="POST" action="/projects/export/" enctype="multipart/form-data" target="_blank">{% csrf_token %}
         <input type="text" name="ecosystem" placeholder="Ecosystem name" required=True><br>
-        <button type="submit" class="btn btn-success">Export Projects File</button>
+        <button type="submit" class="btn btn-success">Download Projects File</button>
     </form>
     </div>
 <!-- END RIGHT COLUMN -->


### PR DESCRIPTION
Addressing your comments from the last PR, these are the changes:

* Now on Bestiary web GUI, export button text is `Download Projects File` instead of `Export Projects File`
* Before, method `export_projects` from `bestiary_export.py` always saved the output in a JSON file which had to be read from Django. Now the method returns a Python dict which can be read from Django directly from memory. In order to keep the previous behaviour, if `bestiary_export.py` is executed from command line it will work as before, exporting the data to a JSON file, but if the `export_projects` method is called with `projects_file` set to `None`, it won't create any JSON file.