### PR TITLE
Support GET requests to obtain exported JSON projects file

### DIFF
--- a/django_bestiary/projects/urls.py
+++ b/django_bestiary/projects/urls.py
@@ -4,6 +4,7 @@ from . import views
 
 urlpatterns = [
     url(r'^import/$', views.import_from_file),
+    url(r'^export/ecosystem=(?P<ecosystem>[\w ]+)', views.export_to_file),
     url(r'^export/$', views.export_to_file),
     url(r'^editor/$', views.editor, name='editor'),
     url(r'^select_ecosystem$', views.select_ecosystem),


### PR DESCRIPTION
Now the `projects.json` file will be returned when Bestiary gets this request: 
`GET /projects/export/ecosystem=<ecosystem_name>`, keeping the previous behaviour.