### PR TITLE
[editor] Add "Add data source" and "Add ecosystem" features

### DIFF
--- a/django_bestiary/projects/forms.py
+++ b/django_bestiary/projects/forms.py
@@ -54,11 +54,21 @@ class BestiaryEditorForm(forms.Form):
 
 class EcosystemForm(BestiaryEditorForm):
 
+    @perfdata
+    def __init__(self, *args, **kwargs):
+        super(EcosystemForm, self).__init__(*args, **kwargs)
+
+        self.fields['ecosystem_name'] = forms.CharField(label='Ecosystem name', max_length=100)
+        self.fields['ecosystem_name'].widget = forms.TextInput(attrs={'class': 'form-control'})
+
+
+class EcosystemsForm(BestiaryEditorForm):
+
     widget = forms.Select(attrs={'class': 'form-control'})
 
     @perfdata
     def __init__(self, *args, **kwargs):
-        super(EcosystemForm, self).__init__(*args, **kwargs)
+        super(EcosystemsForm, self).__init__(*args, **kwargs)
 
         choices = ()
 

--- a/django_bestiary/projects/forms.py
+++ b/django_bestiary/projects/forms.py
@@ -120,6 +120,16 @@ class ProjectsForm(BestiaryEditorForm):
                                                 widget=self.widget, choices=choices)
 
 
+class DataSourceForm(BestiaryEditorForm):
+
+    @perfdata
+    def __init__(self, *args, **kwargs):
+        super(DataSourceForm, self).__init__(*args, **kwargs)
+
+        self.fields['data_source_name'] = forms.CharField(label='Data source name', max_length=100)
+        self.fields['data_source_name'].widget = forms.TextInput(attrs={'class': 'form-control'})
+
+
 class DataSourcesForm(BestiaryEditorForm):
 
     @perfdata

--- a/django_bestiary/projects/templates/projects/editor.html
+++ b/django_bestiary/projects/templates/projects/editor.html
@@ -21,19 +21,28 @@
   <div class="col-sm">
     <form action="/select_ecosystem" method="post">
       {% csrf_token %}
-      {% for field in ecosystem_form.state_fields %}
+      {% for field in ecosystems_form.state_fields %}
         {{ field }}
       {% endfor %}
-      {{ ecosystem_form.name.errors }}
+      {{ ecosystems_form.name.errors }}
       <div class="form-group row">
         <div class="col-sm-7">
-          {{ ecosystem_form.name }}
+          {{ ecosystems_form.name }}
         </div>
         <div class="col-sm-5">
           <button type="submit" class="btn btn-primary">Select Ecosystem</button>
         </div>
       </div>
     </form>
+  </div>
+  <div class="col-sm">
+    <form action="/add_ecosystem" method="post">
+        {% csrf_token %}
+        <div class="form-group row">
+            <div class="col-sm-4">{{ ecosystem_form.ecosystem_name }}</div>
+            <div class="col-sm-3"><input type="submit" value="Add ecosystem" class="form-control"></div>
+      </form>
+  </div>
   </div>
 </div>
 

--- a/django_bestiary/projects/templates/projects/editor.html
+++ b/django_bestiary/projects/templates/projects/editor.html
@@ -90,9 +90,12 @@
       <div class="form-group">
         <button type="submit" class="btn btn-primary">Select Data Source</button>
       </div>
+      </form>
+      <form action="/add_data_source" method="post">
+        {% csrf_token %}
       <div class="form-group row">
-        <div class="col-sm-7"><input type="text" name="data_source_name_add" placeholder="name" class="form-control"></div>
-        <div class="col-sm-5"><input type="button" value="Add data source type" class="form-control"></div>
+        <div class="col-sm-7">{{ data_source_form.data_source_name }}</div>
+        <div class="col-sm-5"><input type="submit" value="Add data source type" class="form-control"></div>
       </div>
       <div class="form-group">
         <input type="button" value="Remove data source" class="form-control">

--- a/django_bestiary/projects/templates/projects/project.html
+++ b/django_bestiary/projects/templates/projects/project.html
@@ -60,7 +60,7 @@
             <div class="modal-body">
                     <div class="input-group">
                         <span class="input-group-addon"><i class="fa fa-globe"></i></span>
-                        {{ ecosystem_form.name }}
+                        {{ ecosystems_form.name }}
                     </div>
             </div>
             <div class="modal-footer">

--- a/django_bestiary/projects/urls.py
+++ b/django_bestiary/projects/urls.py
@@ -7,6 +7,7 @@ urlpatterns = [
     url(r'^export/ecosystem=(?P<ecosystem>[\w ]+)', views.export_to_file),
     url(r'^export/$', views.export_to_file),
     url(r'^editor/$', views.editor, name='editor'),
+    url(r'^add_ecosystem$', views.add_ecosystem),
     url(r'^select_ecosystem$', views.select_ecosystem),
     url(r'^add_project$', views.add_project),
     url(r'^remove_project$', views.remove_project),

--- a/django_bestiary/projects/urls.py
+++ b/django_bestiary/projects/urls.py
@@ -11,6 +11,7 @@ urlpatterns = [
     url(r'^add_project$', views.add_project),
     url(r'^remove_project$', views.remove_project),
     url(r'^select_project$', views.select_project),
+    url(r'^add_data_source$', views.add_data_source),
     url(r'^select_data_source$', views.select_data_source),
     url(r'^add_repository_view$', views.add_repository_view),
     url(r'^remove_repository_view$', views.remove_repository_view),

--- a/django_bestiary/projects/views.py
+++ b/django_bestiary/projects/views.py
@@ -98,6 +98,7 @@ def build_forms_context(state=None):
     projects_form = forms.ProjectsForm(state=state)
     project_form = forms.ProjectForm(state=state)
     project_remove_form = None
+    data_source_form = forms.DataSourceForm(state=state)
     data_sources_form = forms.DataSourcesForm(state=state)
     repository_views_form = forms.RepositoryViewsForm(state=state)
     repository_view_form = forms.RepositoryViewForm(state=state)
@@ -115,6 +116,7 @@ def build_forms_context(state=None):
                "projects_form": projects_form,
                "project_form": project_form,
                "project_remove_form": project_remove_form,
+               "data_source_form": data_source_form,
                "data_sources_form": data_sources_form,
                "repository_views_form": repository_views_form,
                "repository_view_form": repository_view_form
@@ -237,6 +239,35 @@ def select_repository_view(request):
             state = EditorState(form=form, repository_views=[repository_view_id])
             return shortcuts.render(request, 'projects/editor.html',
                                     build_forms_context(state))
+        else:
+            # TODO: Show error
+            raise Http404
+    # if a GET (or any other method) we'll create a blank form
+    else:
+        # TODO: Show error
+        return shortcuts.render(request, 'projects/editor.html', build_forms_context())
+
+
+def add_data_source(request):
+
+    if request.method == 'POST':
+        form = forms.DataSourceForm(request.POST)
+        if form.is_valid():
+            eco_name = form.cleaned_data['eco_name_state']
+            eco_orm = None
+            project_name = form.cleaned_data['projects_state']
+            project_orm = None
+            if eco_name:
+                eco_orm = Ecosystem.objects.get(name=eco_name)
+                projects_orm = eco_orm.projects.all()
+                eco_orm.save()
+
+            data_source_name = form.cleaned_data['data_source_name']
+            data_source_orm = DataSource(name=data_source_name)
+            data_source_orm.save()
+
+            return shortcuts.render(request, 'projects/editor.html',
+                                    build_forms_context(EditorState(form=form)))
         else:
             # TODO: Show error
             raise Http404


### PR DESCRIPTION
Changes included with "Add data source" feature:
 - New Django Form: `DataSourceForm` with the field `data_source_name`
 - Add new form to the editor template
 - Add form action url to `urls.py`
 - Add `add_data_source` method in `views.py`

Changes included with "Add ecosystem" feature:
 - Rename form `EcosystemForm` as `EcosystemsForm` to match the format
   with the rest of Forms, as forms with plural names are used
   to show a list of objects and singular names are used to add
   a new object of that class.
 - Add form `EcosystemForm` for the new `Add Ecosystem` feature.
   This was the reason for the renaming (see previous point).
 - Modify editor template with the new `Add Ecosystem` form
 - Add `add_ecosystem` method to `views.py`.
 - Add new `urlpattern` to `urls.py` for supporting the new form.