### PR TITLE
Fix patch for "Data source type" form, add empty choice to select forms

### DIFF
--- a/django_bestiary/projects/data.py
+++ b/django_bestiary/projects/data.py
@@ -1,4 +1,5 @@
 from projects.models import DataSource, Ecosystem, Project, Repository, RepositoryView
+from grimoire_elk import utils as gelk_utils
 
 
 class DataSourcesData():
@@ -26,7 +27,9 @@ class DataSourcesData():
     def fetch(self):
 
         if not self.state or self.state.is_empty():
-            for data_source in DataSource.objects.all():
+            supported_data_sources = list(gelk_utils.get_connectors())
+            for data_source_name in supported_data_sources:
+                data_source = DataSource(name=data_source_name)
                 yield data_source
         elif self.state.data_sources:
             data_sources = DataSource.objects.filter(name__in=self.state.data_sources)

--- a/django_bestiary/projects/forms.py
+++ b/django_bestiary/projects/forms.py
@@ -4,7 +4,8 @@ from time import time
 
 from django import forms
 
-from projects.models import DataSource, Project, RepositoryView
+
+from projects.models import Project, RepositoryView
 
 from . import data
 
@@ -73,12 +74,12 @@ class EcosystemsForm(BestiaryEditorForm):
     def __init__(self, *args, **kwargs):
         super(EcosystemsForm, self).__init__(*args, **kwargs)
 
-        choices = ()
+        choices = [('', '')]  # Initial empty choice
 
         for eco in data.EcosystemsData(self.state).fetch():
             choices += ((eco.name, eco.name),)
 
-        self.fields['name'] = forms.ChoiceField(label='Ecosystems',
+        self.fields['name'] = forms.ChoiceField(label='Ecosystems', required=True,
                                                 widget=self.widget, choices=choices)
 
 
@@ -200,23 +201,15 @@ class RepositoryViewForm(BestiaryEditorForm):
 
         choices = ()
 
-        if self.state and self.state.data_sources:
-            for ds_name in self.state.data_sources:
-                choices += ((ds_name, ds_name),)
-        elif self.repository_view_id:
-            repository_view_orm = RepositoryView.objects.get(id=self.repository_view_id)
-            ds_name = repository_view_orm.repository.data_source.name
-            choices += ((ds_name, ds_name),)
-        else:
-            for ds in DataSource.objects.all():
-                choices += ((ds.name, ds.name),)
+        for ds in data.DataSourcesData(state=None).fetch():
+            choices += ((ds.name, ds.name),)
 
-        choices = sorted(choices, key=lambda x: x[1])
+        empty_choice = [('', '')]
+        choices = empty_choice + sorted(choices, key=lambda x: x[1])
 
         self.widget = forms.Select(attrs={'class': 'form-control'})
-        self.fields['data_source'] = forms.CharField(label='Data Source',
-                                                     max_length=100, required=False)
-        self.fields['data_source'].widget = forms.HiddenInput(attrs={'class': 'form-control', 'readonly': 'True'})
+        self.fields['data_source'] = forms.ChoiceField(label='Data Source', required=True,
+                                                       widget=self.widget, choices=choices)
 
         self.fields['project'] = forms.CharField(label='project', max_length=100, required=False)
         self.fields['project'].widget = forms.HiddenInput(attrs={'class': 'form-control', 'readonly': 'True'})

--- a/django_bestiary/projects/templates/projects/editor.html
+++ b/django_bestiary/projects/templates/projects/editor.html
@@ -143,43 +143,7 @@
               <button type="button" class="close" data-dismiss="modal">&times;</button>
             </div>
             <div class="modal-body">
-
-                <div class="form-group row">
-                    <label class="col-sm-2 col-form-label">Type:</label>
-                    <div class="col-sm-10">
-                        <select id="selected_ds_rv_modal" class="form-control" onclick='document.getElementById("id_data_source").value = this.value;'>
-                            <option disabled selected value> Select data source </option>
-                            <option>askbot</option>
-                            <option>bugzilla</option>
-                            <option>bugzillarest</option>
-                            <option>confluence</option>
-                            <option>discourse</option>
-                            <option>dockerhub</option>
-                            <option>gerrit</option>
-                            <option>git</option>
-                            <option>github</option>
-                            <option>gmane</option>
-                            <option>hyperkitty</option>
-                            <option>jenkins</option>
-                            <option>jira</option>
-                            <option>launchpad</option>
-                            <option>mbox</option>
-                            <option>mediawiki</option>
-                            <option>meetup</option>
-                            <option>nntp</option>
-                            <option>phabricator</option>
-                            <option>pipermail</option>
-                            <option>redmine</option>
-                            <option>rss</option>
-                            <option>slack</option>
-                            <option>stackexchange</option>
-                            <option>supybot</option>
-                            <option>telegram</option>
-                            <option>twitter</option>
-                        </select>
-                    </div>
-                </div>
-                <div class="input-group"> {{ repository_view_form.data_source }}</div>
+                <div class="input-group"><span class="input-group-addon">Data source type</span>{{ repository_view_form.data_source }}</div>
                 <div class="input-group">
                   <span class="input-group-addon"><i class="fa fa-external-link"></i></span>
                   {{ repository_view_form.repository }}
@@ -370,14 +334,6 @@ eco_download_form = document.getElementById("ecosystem_download");
 eco_download_form["name"].removeAttribute("onclick");
 eco_download_form = document.getElementById("ecosystem_import");
 eco_download_form["name"].removeAttribute("onclick");
-
-// Copy the value from selected data source for update state into
-// Add/Edit RepositoryView modals.
-selected_repo = document.getElementById("id_repository").value;
-current_ds_state = document.getElementById("id_data_sources_state").value;
-
-document.getElementById("selected_ds_rv_modal").value = current_ds_state;
-document.getElementById("id_data_source").value = current_ds_state;
 
 // Functions to show/hide buttons on modals depending on the action.
 function showAddButtons() {


### PR DESCRIPTION
 - Now every option for select a `Data source type` is retrieved from GrimoireELK, so we only have those types which are supported by the GrimoireLab platform.

- Add an empty choice to `Select` forms, so it is more clear that no option is selected by default.

- Remove unused module in `forms.py` (flake8).