### PR TITLE
Prevent unwilled requests in select forms, update state when add an ecosystem or project

### DIFF
--- a/django_bestiary/projects/views.py
+++ b/django_bestiary/projects/views.py
@@ -112,6 +112,9 @@ def select_ecosystem(request, template, context=None):
         form = forms.EcosystemsForm(request.POST)
         if form.is_valid():
             name = form.cleaned_data['name']
+            if not name:
+                # TODO: Show error when ecosystem name is empty
+                return shortcuts.render(request, template, build_forms_context())
             # Select and ecosystem reset the state. Don't pass form=form
             state = build_forms_context(EditorState(eco_name=name))
             if context:
@@ -120,9 +123,8 @@ def select_ecosystem(request, template, context=None):
                 context = build_forms_context(EditorState(eco_name=name))
             return shortcuts.render(request, template, context)
         else:
-            # TODO: Show error
-            print("FORM errors", form.errors)
-            raise Http404
+            # Ignore when the empty option is selected
+            return shortcuts.render(request, template, build_forms_context())
     # if a GET (or any other method) we'll create a blank form
     else:
         # TODO: Show error

--- a/django_bestiary/projects/views.py
+++ b/django_bestiary/projects/views.py
@@ -475,8 +475,9 @@ def add_project(request):
                 eco_orm = Ecosystem.objects.get(name=eco_name)
                 eco_orm.projects.add(project_orm)
                 eco_orm.save()
+            context = EditorState(projects=[project_name], form=form)
             return shortcuts.render(request, 'projects/editor.html',
-                                    build_forms_context(EditorState(form=form)))
+                                    build_forms_context(context))
         else:
             # TODO: Show error
             raise Http404
@@ -568,7 +569,7 @@ def import_from_file(request):
         print("Projects loaded", nprojects)
         print("Repositories loaded", nrepos)
 
-    return editor(request)
+    return editor_select_ecosystem(request)
 
 
 def export_to_file(request, ecosystem=None):


### PR DESCRIPTION
* This patch aims to fix a side-effect that appeared when the `onclick` event was added to the select ecosystem forms. As the first option is empty (to show the user that no ecosystem has been selected), when that empty option is clicked it submits the data and it provoked an error. 
Now, our `select_ecosystem` method ignores forms with an empty name, returning to the editor keeping its previous state.

* Now, when an Ecosystem is created, it is added to the editor state, so that ecosytem is now selected when the response loads. If a Project is created, now it is added to the editor state also, in addition to preserve its previous state.

